### PR TITLE
refactor(config): replace config crate with figment for better layering ergonomics

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -78,7 +78,7 @@ Configuration files are discovered automatically in order of precedence (highest
 2. `{{ project_name }}.<ext>` in current directory or any parent
 3. `~/.config/{{ project_name }}/config.<ext>` (user config)
 
-**Supported formats:** TOML, YAML, JSON, JSON5 (extensions: `.toml`, `.yaml`, `.yml`, `.json`, `.json5`)
+**Supported formats:** TOML, YAML, JSON (extensions: `.toml`, `.yaml`, `.yml`, `.json`)
 
 Values from higher-precedence files override lower ones. Missing files are silently ignored.
 

--- a/template/crates/{{project_name + "-core" if has_core_library else "__skip_core__"}}/Cargo.toml.jinja
+++ b/template/crates/{{project_name + "-core" if has_core_library else "__skip_core__"}}/Cargo.toml.jinja
@@ -33,7 +33,7 @@ exclude = [
 [dependencies]
 {% if has_config -%}
 camino = { version = "1.1", features = ["serde1"] }
-config = { version = "0.15", default-features = false, features = ["toml", "yaml", "json", "json5"] }
+figment = { version = "0.10", features = ["toml", "yaml", "json"] }
 dirs = "6.0"
 serde = { version = "1.0", features = ["derive"] }
 {% endif -%}

--- a/template/crates/{{project_name + "-core" if has_core_library else "__skip_core__"}}/src/error.rs.jinja
+++ b/template/crates/{{project_name + "-core" if has_core_library else "__skip_core__"}}/src/error.rs.jinja
@@ -1,26 +1,14 @@
 //! Error types for {{ project_name }}-core
-{% if has_config %}
-use camino::Utf8PathBuf;
-{% endif %}
+
 use thiserror::Error;
 
 /// Errors that can occur when working with configuration.
 #[derive(Error, Debug)]
 pub enum ConfigError {
 {% if has_config -%}
-    /// Failed to load configuration from a file.
-    #[error("failed to load config from {path}: {source}")]
-    Load {
-        /// Path to the config file that failed to load.
-        path: Utf8PathBuf,
-        /// The underlying configuration error.
-        #[source]
-        source: config::ConfigError,
-    },
-
     /// Failed to deserialize configuration.
     #[error("invalid configuration: {0}")]
-    Deserialize(#[from] config::ConfigError),
+    Deserialize(#[from] Box<figment::Error>),
 {% endif %}
     /// Configuration file not found after searching all locations.
     #[error("no configuration file found")]

--- a/template/crates/{{project_name + "-core" if has_core_library else "__skip_core__"}}/src/{{"config.rs" if has_config else "__skip_config__.rs"}}.jinja
+++ b/template/crates/{{project_name + "-core" if has_core_library else "__skip_core__"}}/src/{{"config.rs" if has_config else "__skip_config__.rs"}}.jinja
@@ -12,14 +12,13 @@
 //! - TOML (`.toml`)
 //! - YAML (`.yaml`, `.yml`)
 //! - JSON (`.json`)
-//! - JSON5 (`.json5`)
 //!
 //! # Config file locations (in order of precedence, highest first):
 //! - `.{{ project_name }}.<ext>` in current directory or any parent
 //! - `{{ project_name }}.<ext>` in current directory or any parent
 //! - `~/.config/{{ project_name }}/config.<ext>` (user config)
 //!
-//! Where `<ext>` is one of: `toml`, `yaml`, `yml`, `json`, `json5`
+//! Where `<ext>` is one of: `toml`, `yaml`, `yml`, `json`
 //!
 //! # Example
 //! ```no_run
@@ -32,8 +31,9 @@
 //! ```
 
 use camino::{Utf8Path, Utf8PathBuf};
-use config::{ConfigBuilder, File, FileFormat, builder::DefaultState};
-use serde::Deserialize;
+use figment::Figment;
+use figment::providers::{Format, Json, Serialized, Toml, Yaml};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::error::{ConfigError, ConfigResult};
@@ -41,8 +41,8 @@ use crate::error::{ConfigError, ConfigResult};
 /// The configuration for {{ project_name }}.
 ///
 /// Add your configuration fields here. This struct is deserialized from
-/// config files found during discovery (TOML, YAML, JSON, or JSON5).
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+/// config files found during discovery (TOML, YAML, or JSON).
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct Config {
     /// Log level for the application (e.g., "debug", "info", "warn", "error").
@@ -56,7 +56,7 @@ pub struct Config {
 }
 
 /// Log level configuration.
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     /// Verbose output for debugging and development.
@@ -83,7 +83,7 @@ impl LogLevel {
 }
 
 /// Supported configuration file extensions (in order of preference).
-const CONFIG_EXTENSIONS: &[&str] = &["toml", "yaml", "yml", "json", "json5"];
+const CONFIG_EXTENSIONS: &[&str] = &["toml", "yaml", "yml", "json"];
 
 /// Application name for XDG directory lookup and config file names.
 const APP_NAME: &str = "{{ project_name }}";
@@ -160,31 +160,30 @@ impl ConfigLoader {
     /// 3. User config (`~/.config/{{ project_name }}/config.<ext>`)
     /// 4. Default values
     pub fn load(self) -> ConfigResult<Config> {
-        let mut builder = config::Config::builder();
+        let mut figment = Figment::new().merge(Serialized::defaults(Config::default()));
 
         // Start with user config (lowest precedence of file sources)
         if self.include_user_config
             && let Some(user_config) = self.find_user_config()
         {
-            builder = self.add_file(builder, &user_config)?;
+            figment = Self::merge_file(figment, &user_config);
         }
 
         // Add project config
         if let Some(ref root) = self.project_search_root
             && let Some(project_config) = self.find_project_config(root)
         {
-            builder = self.add_file(builder, &project_config)?;
+            figment = Self::merge_file(figment, &project_config);
         }
 
         // Add explicit files (highest precedence)
         for file in &self.explicit_files {
-            builder = self.add_file(builder, file)?;
+            figment = Self::merge_file(figment, file);
         }
 
-        builder
-            .build()?
-            .try_deserialize()
-            .map_err(ConfigError::from)
+        figment
+            .extract()
+            .map_err(|e| ConfigError::Deserialize(Box::new(e)))
     }
 
     /// Load configuration, returning an error if no config file is found.
@@ -255,24 +254,13 @@ impl ConfigLoader {
         None
     }
 
-    /// Add a file to the config builder, detecting format from extension.
-    fn add_file(
-        &self,
-        builder: ConfigBuilder<DefaultState>,
-        path: &Utf8Path,
-    ) -> ConfigResult<ConfigBuilder<DefaultState>> {
-        let format = Self::detect_format(path);
-        Ok(builder.add_source(File::new(path.as_str(), format)))
-    }
-
-    /// Detect the file format from the file extension.
-    fn detect_format(path: &Utf8Path) -> FileFormat {
+    /// Merge a config file into the figment, detecting format from extension.
+    fn merge_file(figment: Figment, path: &Utf8Path) -> Figment {
         match path.extension() {
-            Some("toml") => FileFormat::Toml,
-            Some("yaml" | "yml") => FileFormat::Yaml,
-            Some("json") => FileFormat::Json,
-            Some("json5") => FileFormat::Json5,
-            _ => FileFormat::Toml, // Default to TOML for unknown extensions
+            Some("toml") => figment.merge(Toml::file_exact(path.as_str())),
+            Some("yaml" | "yml") => figment.merge(Yaml::file_exact(path.as_str())),
+            Some("json") => figment.merge(Json::file_exact(path.as_str())),
+            _ => figment.merge(Toml::file_exact(path.as_str())),
         }
     }
 }

--- a/template/crates/{{project_name if has_cli else "__skip_cli__"}}/Cargo.toml.jinja
+++ b/template/crates/{{project_name if has_cli else "__skip_cli__"}}/Cargo.toml.jinja
@@ -68,8 +68,9 @@ serde_json = "1.0"
 dirs = "6.0"
 {% endif -%}
 {% if has_config and not has_core_library -%}
-camino = "1.1"
-config = "0.15"
+camino = { version = "1.1", features = ["serde1"] }
+dirs = "6.0"
+figment = { version = "0.10", features = ["toml", "yaml", "json"] }
 thiserror = "2.0"
 {% endif %}
 [dev-dependencies]

--- a/template/crates/{{project_name if has_cli else "__skip_cli__"}}/tests/{{"config_integration.rs" if has_config else "__skip_config_integration__.rs"}}.jinja
+++ b/template/crates/{{project_name if has_cli else "__skip_cli__"}}/tests/{{"config_integration.rs" if has_config else "__skip_config_integration__.rs"}}.jinja
@@ -164,25 +164,6 @@ fn parses_json_config() {
         .success();
 }
 
-#[test]
-fn parses_json5_config() {
-    let tmp = TempDir::new().unwrap();
-    fs::write(
-        tmp.path().join(".{{ project_name }}.json5"),
-        r#"{
-    // JSON5 supports comments
-    log_level: "warn",
-    // And trailing commas
-}"#,
-    )
-    .unwrap();
-
-    cmd()
-        .args(["-C", tmp.path().to_str().unwrap(), "info"])
-        .assert()
-        .success();
-}
-
 // =============================================================================
 // Config Precedence
 // =============================================================================
@@ -289,7 +270,7 @@ fn invalid_json_config_shows_error() {
 
 #[test]
 fn unknown_config_field_is_ignored() {
-    // The config crate ignores unknown fields by default with serde
+    // Figment ignores unknown fields by default with serde
     let tmp = TempDir::new().unwrap();
     fs::write(
         tmp.path().join(".{{ project_name }}.toml"),

--- a/template/{{"config" if has_config else "__skip_config__"}}/{{project_name + ".toml.example" if has_config else "__skip_toml_example__"}}.jinja
+++ b/template/{{"config" if has_config else "__skip_config__"}}/{{project_name + ".toml.example" if has_config else "__skip_toml_example__"}}.jinja
@@ -5,8 +5,8 @@
 #   - {{project_name}}.toml (in your project directory)
 #   - ~/.config/{{project_name}}/config.toml (user-wide config)
 #
-# Supported formats: TOML, YAML, JSON, JSON5
-# (use the appropriate extension: .toml, .yaml, .yml, .json, .json5)
+# Supported formats: TOML, YAML, JSON
+# (use the appropriate extension: .toml, .yaml, .yml, .json)
 #
 # Configuration files are discovered automatically. Project-level configs
 # take precedence over user-level configs. The search stops at repository

--- a/template/{{"config" if has_config else "__skip_config__"}}/{{project_name + ".yaml.example" if has_config else "__skip_yaml_example__"}}.jinja
+++ b/template/{{"config" if has_config else "__skip_config__"}}/{{project_name + ".yaml.example" if has_config else "__skip_yaml_example__"}}.jinja
@@ -5,8 +5,8 @@
 #   - {{project_name}}.yaml (in your project directory)
 #   - ~/.config/{{project_name}}/config.yaml (user-wide config)
 #
-# Supported formats: TOML, YAML, JSON, JSON5
-# (use the appropriate extension: .toml, .yaml, .yml, .json, .json5)
+# Supported formats: TOML, YAML, JSON
+# (use the appropriate extension: .toml, .yaml, .yml, .json)
 #
 # Configuration files are discovered automatically. Project-level configs
 # take precedence over user-level configs. The search stops at repository


### PR DESCRIPTION
The config crate's error model required a separate Load variant for
per-file failures, adding complexity that figment's deferred-extraction
approach eliminates. Figment also provides provenance tracking (which
source set a given value) and a first-class Serialized::defaults()
provider, both useful for debugging config layering.
Drop JSON5 format support (figment has no JSON5 provider; it was
rarely used). Box figment::Error in the Deserialize variant to
satisfy the large_enum_variant lint (208 bytes vs zero-size NotFound).
Fix pre-existing bug: CLI Cargo.toml was missing dirs and camino's
serde1 feature for the no-core-library path.