### PR TITLE
feat(template): add post-copy messages and configurable clippy lint tiers

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -30,6 +30,32 @@ _exclude:
   - "*__skip_*"
 # Use .jinja suffix for template files
 _templates_suffix: .jinja
+
+_message_after_copy: |
+
+  -------------------------------------------------------
+  Project "{{ project_name }}" created successfully!
+  -------------------------------------------------------
+
+  Get started:
+
+    cd {{ project_name }}
+  {%- if has_just %}
+    just bootstrap
+  {%- else %}
+    cargo build --workspace
+  {%- endif %}
+
+_message_after_update: |
+
+  Project "{{ project_name }}" updated.
+  Review changes and run:
+  {%- if has_just %}
+    just check
+  {%- else %}
+    cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run
+  {%- endif %}
+
 # =============================================================================
 # Post-generation tasks (requires --trust flag)
 # =============================================================================
@@ -160,6 +186,17 @@ preset:
     "Full (everything including benchmarks and site)": "full"
   default: "standard"
   help: "Project template preset - sets defaults for feature flags"
+# =============================================================================
+# Code Quality
+# =============================================================================
+lint_level:
+  type: str
+  choices:
+    "Strict (all + nursery warnings)": "strict"
+    "Standard (all warnings, no nursery)": "standard"
+    "Relaxed (Rust defaults only)": "relaxed"
+  default: "{% if preset == 'full' %}strict{% else %}standard{% endif %}"
+  help: "Clippy lint strictness for [workspace.lints.clippy]"
 # =============================================================================
 # Feature Flags (Override Preset Defaults)
 # =============================================================================

--- a/scripts/presets/full.yml
+++ b/scripts/presets/full.yml
@@ -12,6 +12,7 @@ license:
 categories:
   - command-line-utilities
 preset: full
+lint_level: strict
 hook_system: none
 has_cli: true
 has_core_library: true

--- a/scripts/presets/minimal.yml
+++ b/scripts/presets/minimal.yml
@@ -11,6 +11,7 @@ license:
 categories:
   - command-line-utilities
 preset: minimal
+lint_level: standard
 hook_system: none
 has_cli: true
 has_core_library: false

--- a/scripts/presets/standard-otel.yml
+++ b/scripts/presets/standard-otel.yml
@@ -11,6 +11,7 @@ license:
 categories:
   - command-line-utilities
 preset: standard
+lint_level: standard
 hook_system: none
 has_cli: true
 has_core_library: true

--- a/scripts/presets/standard.yml
+++ b/scripts/presets/standard.yml
@@ -11,6 +11,7 @@ license:
 categories:
   - command-line-utilities
 preset: standard
+lint_level: standard
 hook_system: none
 has_cli: true
 has_core_library: true

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -798,6 +798,7 @@ license:
 categories:
   - command-line-utilities
 preset: minimal
+lint_level: standard
 hook_system: none
 has_cli: true
 has_core_library: false
@@ -849,6 +850,7 @@ license:
 categories:
   - command-line-utilities
 preset: standard
+lint_level: standard
 hook_system: none
 has_cli: true
 has_core_library: true
@@ -901,6 +903,7 @@ license:
 categories:
   - command-line-utilities
 preset: standard
+lint_level: standard
 hook_system: none
 has_cli: true
 has_core_library: true
@@ -954,6 +957,7 @@ license:
 categories:
   - command-line-utilities
 preset: full
+lint_level: strict
 hook_system: none
 has_cli: true
 has_core_library: true

--- a/template/Cargo.toml.jinja
+++ b/template/Cargo.toml.jinja
@@ -24,9 +24,13 @@ unsafe_code = "deny"
 # Encourage documentation - warn on public items missing docs
 missing_docs = "warn"
 
+{%- if lint_level != 'relaxed' %}
 [workspace.lints.clippy]
 all = "warn"
+{%- if lint_level == 'strict' %}
 nursery = "warn"
+{%- endif %}
+{%- endif %}
 
 # Optimize dependencies in dev mode for faster tests
 # (keeps main crate unoptimized for fast incremental builds)

--- a/template/{{ ".claude" if has_claude else "__skip_claude__" }}/{{ "rules" if has_claude_rules else "__skip_rules__" }}/rust-dev-guidelines.md
+++ b/template/{{ ".claude" if has_claude else "__skip_claude__" }}/{{ "rules" if has_claude_rules else "__skip_rules__" }}/rust-dev-guidelines.md
@@ -46,7 +46,7 @@ Useful for:
 edition = "2024"
 rust-version = "1.88.0"
 unsafe_code = "deny"
-clippy: all = "warn", nursery = "warn"
+clippy: see [workspace.lints.clippy] in Cargo.toml
 ```
 
 ---

--- a/test/conditional_files.bats
+++ b/test/conditional_files.bats
@@ -231,6 +231,54 @@ load 'test_helper'
 }
 
 # =============================================================================
+# Clippy Lint Tiers
+# =============================================================================
+
+@test "lint_level=strict includes all + nursery warnings" {
+    local output_dir
+    output_dir=$(generate_project_with_data "cond-lint-strict" "minimal.yml" \
+        "lint_level=strict" \
+        "has_github=false" \
+        "has_claude=false" \
+        "has_just=false" \
+        "has_agents_md=false" \
+        "has_gitattributes=false" \
+        "has_md=false")
+
+    assert_file_contains "$output_dir" "Cargo.toml" 'all = "warn"'
+    assert_file_contains "$output_dir" "Cargo.toml" 'nursery = "warn"'
+}
+
+@test "lint_level=standard includes all warnings but no nursery" {
+    local output_dir
+    output_dir=$(generate_project_with_data "cond-lint-standard" "minimal.yml" \
+        "lint_level=standard" \
+        "has_github=false" \
+        "has_claude=false" \
+        "has_just=false" \
+        "has_agents_md=false" \
+        "has_gitattributes=false" \
+        "has_md=false")
+
+    assert_file_contains "$output_dir" "Cargo.toml" 'all = "warn"'
+    assert_file_not_contains "$output_dir" "Cargo.toml" 'nursery = "warn"'
+}
+
+@test "lint_level=relaxed omits clippy lint section" {
+    local output_dir
+    output_dir=$(generate_project_with_data "cond-lint-relaxed" "minimal.yml" \
+        "lint_level=relaxed" \
+        "has_github=false" \
+        "has_claude=false" \
+        "has_just=false" \
+        "has_agents_md=false" \
+        "has_gitattributes=false" \
+        "has_md=false")
+
+    assert_file_not_contains "$output_dir" "Cargo.toml" '\[workspace\.lints\.clippy\]'
+}
+
+# =============================================================================
 # Template Sanity Checks
 # =============================================================================
 


### PR DESCRIPTION
Give users immediate next-step guidance after `copier copy` and
`copier update` via _message_after_copy/_message_after_update.
Add a `lint_level` variable (strict/standard/relaxed) so generated
projects can choose their clippy strictness independently of the
preset. Defaults: minimal/standard → standard, full → strict.