### PR TITLE
fix(template): address code review findings and wire up CLI flags

### DIFF
--- a/template/crates/{{ project_name + "-core" if has_core_library else "" }}/src/{% if has_config %}config.rs{% endif %}.jinja
+++ b/template/crates/{{ project_name + "-core" if has_core_library else "" }}/src/{% if has_config %}config.rs{% endif %}.jinja
@@ -22,10 +22,13 @@
 //!
 //! # Example
 //! ```no_run
+//! use camino::Utf8PathBuf;
 //! use {{ crate_name }}_core::config::{Config, ConfigLoader};
 //!
+//! let cwd = std::env::current_dir().unwrap();
+//! let cwd = Utf8PathBuf::try_from(cwd).expect("current directory is not valid UTF-8");
 //! let config = ConfigLoader::new()
-//!     .with_project_search(std::env::current_dir().unwrap())
+//!     .with_project_search(&cwd)
 //!     .load()
 //!     .unwrap();
 //! ```
@@ -34,7 +37,6 @@ use camino::{Utf8Path, Utf8PathBuf};
 use figment::Figment;
 use figment::providers::{Format, Json, Serialized, Toml, Yaml};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 
 use crate::error::{ConfigError, ConfigResult};
 
@@ -115,8 +117,8 @@ impl ConfigLoader {
     /// Set the starting directory for project config search.
     ///
     /// The loader will walk up from this directory looking for config files.
-    pub fn with_project_search<P: AsRef<Path>>(mut self, path: P) -> Self {
-        self.project_search_root = Utf8PathBuf::from_path_buf(path.as_ref().to_path_buf()).ok();
+    pub fn with_project_search<P: AsRef<Utf8Path>>(mut self, path: P) -> Self {
+        self.project_search_root = Some(path.as_ref().to_path_buf());
         self
     }
 
@@ -145,10 +147,8 @@ impl ConfigLoader {
     ///
     /// Files are loaded in order, with later files taking precedence.
     /// Explicit files are loaded after discovered files.
-    pub fn with_file<P: AsRef<Path>>(mut self, path: P) -> Self {
-        if let Ok(utf8_path) = Utf8PathBuf::from_path_buf(path.as_ref().to_path_buf()) {
-            self.explicit_files.push(utf8_path);
-        }
+    pub fn with_file<P: AsRef<Utf8Path>>(mut self, path: P) -> Self {
+        self.explicit_files.push(path.as_ref().to_path_buf());
         self
     }
 
@@ -272,12 +272,11 @@ impl ConfigLoader {
 /// Find the project config file path without loading it.
 ///
 /// Useful for commands that need to know where config is located.
-pub fn find_project_config<P: AsRef<Path>>(start: P) -> Option<Utf8PathBuf> {
-    let start = Utf8PathBuf::from_path_buf(start.as_ref().to_path_buf()).ok()?;
+pub fn find_project_config<P: AsRef<Utf8Path>>(start: P) -> Option<Utf8PathBuf> {
     ConfigLoader::new()
-        .with_project_search(&start)
+        .with_project_search(start.as_ref())
         .without_boundary_marker()
-        .find_project_config(&start)
+        .find_project_config(start.as_ref())
 }
 
 /// Get the user config directory path.
@@ -334,6 +333,9 @@ log_dir = "/tmp/{{ project_name }}"
         )
         .unwrap();
 
+        // Convert to Utf8PathBuf for API call
+        let config_path = Utf8PathBuf::try_from(config_path).unwrap();
+
         let config = ConfigLoader::new()
             .with_user_config(false)
             .with_file(&config_path)
@@ -363,6 +365,10 @@ log_dir = "/tmp/{{ project_name }}"
         let override_config = tmp.path().join("override.toml");
         fs::write(&override_config, r#"log_level = "error""#).unwrap();
 
+        // Convert to Utf8PathBuf for API calls
+        let base_config = Utf8PathBuf::try_from(base_config).unwrap();
+        let override_config = Utf8PathBuf::try_from(override_config).unwrap();
+
         let config = ConfigLoader::new()
             .with_user_config(false)
             .with_file(&base_config)
@@ -384,6 +390,9 @@ log_dir = "/tmp/{{ project_name }}"
         // Create config in project root
         let config_path = project_dir.join(".{{ project_name }}.toml");
         fs::write(&config_path, r#"log_level = "debug""#).unwrap();
+
+        // Convert to Utf8PathBuf for API call
+        let sub_dir = Utf8PathBuf::try_from(sub_dir).unwrap();
 
         // Search from deep subdirectory
         let config = ConfigLoader::new()
@@ -412,6 +421,9 @@ log_dir = "/tmp/{{ project_name }}"
         // .git marker in child
         fs::create_dir(child.join(".git")).unwrap();
 
+        // Convert to Utf8PathBuf for API call
+        let work = Utf8PathBuf::try_from(work).unwrap();
+
         // Search from work directory - should not find parent config
         let config = ConfigLoader::new()
             .with_user_config(false)
@@ -436,10 +448,14 @@ log_dir = "/tmp/{{ project_name }}"
         let override_config = tmp.path().join("override.toml");
         fs::write(&override_config, r#"log_level = "error""#).unwrap();
 
+        // Convert to Utf8PathBuf for API calls
+        let tmp_path = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let override_config = Utf8PathBuf::try_from(override_config).unwrap();
+
         let config = ConfigLoader::new()
             .with_user_config(false)
             .without_boundary_marker()
-            .with_project_search(tmp.path())
+            .with_project_search(&tmp_path)
             .with_file(&override_config)
             .load()
             .unwrap();
@@ -463,6 +479,9 @@ log_dir = "/tmp/{{ project_name }}"
         let tmp = TempDir::new().unwrap();
         let config_path = tmp.path().join("config.toml");
         fs::write(&config_path, r#"log_level = "debug""#).unwrap();
+
+        // Convert to Utf8PathBuf for API call
+        let config_path = Utf8PathBuf::try_from(config_path).unwrap();
 
         let config = ConfigLoader::new()
             .with_user_config(false)

--- a/template/crates/{{ project_name + "-core" if has_core_library else "" }}/{% if has_benchmarks %}benches{% endif %}/divan_benchmarks.rs.jinja
+++ b/template/crates/{{ project_name + "-core" if has_core_library else "" }}/{% if has_benchmarks %}benches{% endif %}/divan_benchmarks.rs.jinja
@@ -29,7 +29,7 @@ mod config {
                 .with_user_config(false)
                 .without_boundary_marker()
                 .load()
-                .unwrap(),
+                .expect("default config should always load successfully"),
         )
     }
 

--- a/template/crates/{{ project_name if has_cli else "" }}/Cargo.toml.jinja
+++ b/template/crates/{{ project_name if has_cli else "" }}/Cargo.toml.jinja
@@ -68,11 +68,14 @@ schemars = "1.0"
 {% endif -%}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+owo-colors = { version = "4.1", features = ["supports-colors"] }
+{% if has_config -%}
+camino = { version = "1.1", features = ["serde1"] }
+{% endif -%}
 {% if has_jsonl_logging or has_opentelemetry -%}
 dirs = "6.0"
 {% endif -%}
 {% if has_config and not has_core_library -%}
-camino = { version = "1.1", features = ["serde1"] }
 dirs = "6.0"
 figment = { version = "0.10", features = ["toml", "yaml", "json"] }
 thiserror = "2.0"

--- a/template/crates/{{ project_name if has_cli else "" }}/src/lib.rs.jinja
+++ b/template/crates/{{ project_name if has_cli else "" }}/src/lib.rs.jinja
@@ -25,6 +25,31 @@ pub mod server;
 use clap::{CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 
+/// Color output preference.
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum ColorChoice {
+    /// Detect terminal capabilities automatically.
+    #[default]
+    Auto,
+    /// Always emit colors.
+    Always,
+    /// Never emit colors.
+    Never,
+}
+
+impl ColorChoice {
+    /// Configure global color output based on this choice.
+    ///
+    /// Call this once at startup to set the color mode.
+    pub fn apply(self) {
+        match self {
+            Self::Auto => {} // owo-colors auto-detects by default
+            Self::Always => owo_colors::set_override(true),
+            Self::Never => owo_colors::set_override(false),
+        }
+    }
+}
+
 /// Command-line interface definition for {{ project_name }}.
 #[derive(Parser)]
 #[command(name = "{{ project_name }}")]
@@ -47,9 +72,9 @@ pub struct Cli {
     #[arg(short, long, global = true, action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Colorize output: auto|always|never
-    #[arg(long, global = true, default_value = "auto")]
-    pub color: String,
+    /// Colorize output
+    #[arg(long, global = true, value_enum, default_value_t)]
+    pub color: ColorChoice,
 
     /// Output as JSON (for scripting)
     #[arg(long, global = true)]

--- a/template/crates/{{ project_name if has_cli else "" }}/src/main.rs.jinja
+++ b/template/crates/{{ project_name if has_cli else "" }}/src/main.rs.jinja
@@ -25,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
 fn main() -> anyhow::Result<()> {
 {% endif -%}
     let cli = Cli::parse();
+    cli.color.apply();
 
     if let Some(ref dir) = cli.chdir {
         std::env::set_current_dir(dir)
@@ -32,8 +33,10 @@ fn main() -> anyhow::Result<()> {
     }
 {% if has_config %}
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let cwd = camino::Utf8PathBuf::try_from(cwd)
+        .map_err(|e| anyhow::anyhow!("current directory is not valid UTF-8: {}", e.into_path_buf().display()))?;
     let config = ConfigLoader::new()
-        .with_project_search(cwd)
+        .with_project_search(&cwd)
         .load()
         .context("failed to load configuration")?;
 {% endif %}
@@ -65,7 +68,7 @@ fn main() -> anyhow::Result<()> {
         verbose = cli.verbose,
         quiet = cli.quiet,
         json = cli.json,
-        color = %cli.color,
+        color = ?cli.color,
         chdir = ?cli.chdir,
         "CLI initialized"
     );

--- a/template/crates/{{ project_name if has_cli else "" }}/src/{% if has_jsonl_logging or has_opentelemetry %}observability.rs{% endif %}.jinja
+++ b/template/crates/{{ project_name if has_cli else "" }}/src/{% if has_jsonl_logging or has_opentelemetry %}observability.rs{% endif %}.jinja
@@ -37,12 +37,17 @@ const LOG_FILE_SUFFIX: &str = ".jsonl";
 /// Configuration for observability setup.
 #[derive(Clone, Debug)]
 pub struct ObservabilityConfig {
+    /// The service name used in log entries and traces.
     pub service: String,
 {% if has_opentelemetry -%}
+    /// Deployment environment (e.g., "dev", "staging", "prod").
     pub env: String,
+    /// Service version, typically from Cargo.toml.
     pub version: String,
+    /// OpenTelemetry OTLP endpoint for trace export (e.g., "http://localhost:4317").
     pub otlp_endpoint: Option<String>,
 {% endif -%}
+    /// Directory for JSONL log files. Falls back to platform defaults if unset.
     pub log_dir: Option<PathBuf>,
 }
 

--- a/template/deny.toml.jinja
+++ b/template/deny.toml.jinja
@@ -52,12 +52,11 @@ db-urls = ["https://github.com/RustSec/advisory-db"]
 
 # Ignore specific advisories (use with caution in enterprise)
 ignore = [
-    # Unmaintained crates in dev/build-time dependencies only (not runtime)
-    # These require upstream projects to migrate; no security vulnerability.
-
+{% if has_benchmarks %}
     # bincode 1.3.3 - via gungraun (dev-dep benchmark harness)
     # Upstream recommends bincode 2.x but gungraun hasn't migrated
     "RUSTSEC-2025-0141",
+{% endif %}
 ]
 
 # ==============================================================================
@@ -75,13 +74,14 @@ deny = []
 
 # Skip duplicate version checks for commonly duplicated crates and
 # transitive dependencies we can't control
-# These come from ML ecosystem (candle, tokenizers) and rmcp having different dep versions
 skip = [
+    # Proc-macro ecosystem - affects all presets
+    { crate = "syn", reason = "proc-macro ecosystem version churn" },
+{% if has_mcp_server or has_benchmarks %}
     # Macro/derive crates with version splits across ecosystems
     { crate = "darling", reason = "rmcp-macros vs tokenizers use different versions" },
     { crate = "darling_core", reason = "follows darling" },
     { crate = "darling_macro", reason = "follows darling" },
-    { crate = "syn", reason = "proc-macro ecosystem version churn" },
 
     # Encoding/serialization
     { crate = "base64", reason = "tokenizers (0.13) vs modern ecosystem (0.22)" },
@@ -108,6 +108,7 @@ skip = [
     { crate = "windows-core", reason = "windows ecosystem version spread" },
     { crate = "windows-sys", reason = "windows ecosystem version spread" },
     { crate = "windows-targets", reason = "windows ecosystem version spread" },
+{% endif %}
 ]
 
 # ==============================================================================

--- a/template/{% if has_xtask %}xtask{% endif %}/src/main.rs.jinja
+++ b/template/{% if has_xtask %}xtask{% endif %}/src/main.rs.jinja
@@ -1,3 +1,16 @@
+//! Build automation tasks for {{ project_name }}.
+//!
+//! This crate provides development utilities:
+//! - `completions` - Generate shell completions
+//! - `man` - Generate man pages
+//! - `install` - Install binary to ~/.bin
+{% if has_benchmarks -%}
+//! - `gen-benchmarks` - Generate benchmark harnesses
+//! - `bench` - Run benchmarks
+{% endif -%}
+//!
+//! Run `cargo xtask --help` to see available commands.
+
 #![deny(unsafe_code)]
 
 mod commands;

--- a/test/conditional_files.bats
+++ b/test/conditional_files.bats
@@ -287,11 +287,11 @@ load 'test_helper'
     output_dir=$(generate_project_with_data "cond-mcp-on" "standard.yml" \
         "has_mcp_server=true")
 
-    assert_file_in_project "$output_dir" "crates/test-standard/src/server.rs"
-    assert_file_in_project "$output_dir" "crates/test-standard/src/commands/serve.rs"
-    assert_file_contains "$output_dir" "crates/test-standard/Cargo.toml" 'rmcp'
-    assert_file_contains "$output_dir" "crates/test-standard/Cargo.toml" 'schemars'
-    assert_file_contains "$output_dir" "crates/test-standard/Cargo.toml" 'tokio'
+    assert_file_in_project "$output_dir" "crates/cond-mcp-on/src/server.rs"
+    assert_file_in_project "$output_dir" "crates/cond-mcp-on/src/commands/serve.rs"
+    assert_file_contains "$output_dir" "crates/cond-mcp-on/Cargo.toml" 'rmcp'
+    assert_file_contains "$output_dir" "crates/cond-mcp-on/Cargo.toml" 'schemars'
+    assert_file_contains "$output_dir" "crates/cond-mcp-on/Cargo.toml" 'tokio'
 }
 
 @test "has_mcp_server=false excludes server.rs and serve command" {
@@ -299,9 +299,9 @@ load 'test_helper'
     output_dir=$(generate_project_with_data "cond-mcp-off" "standard.yml" \
         "has_mcp_server=false")
 
-    assert_no_file_in_project "$output_dir" "crates/test-standard/src/server.rs"
-    assert_no_file_in_project "$output_dir" "crates/test-standard/src/commands/serve.rs"
-    assert_file_not_contains "$output_dir" "crates/test-standard/Cargo.toml" 'rmcp'
+    assert_no_file_in_project "$output_dir" "crates/cond-mcp-off/src/server.rs"
+    assert_no_file_in_project "$output_dir" "crates/cond-mcp-off/src/commands/serve.rs"
+    assert_file_not_contains "$output_dir" "crates/cond-mcp-off/Cargo.toml" 'rmcp'
 }
 
 @test "has_mcp_server=true includes MCP development guide" {


### PR DESCRIPTION
- Remove duplicate --json flag from InfoArgs (use global flag only)
- Add ColorChoice ValueEnum for --color validation (auto|always|never)
- Wire up --color flag with owo-colors crate for colored output
- Enforce UTF-8 paths in ConfigLoader API (AsRef<Utf8Path>)
- Document ObservabilityConfig fields to satisfy missing_docs lint
- Make deny.toml skip list conditional on has_mcp_server/has_benchmarks
- Add crate-level documentation to xtask
- Use .expect() instead of .unwrap() in benchmarks for clearer CI errors
- Fix test assertions in conditional_files.bats (wrong project names)