### PR TITLE
fix(test): correct preset filename and test assertions

### DIFF
--- a/test/otel.bats
+++ b/test/otel.bats
@@ -33,7 +33,7 @@ setup() {
 
     # Generate if not already present
     if [[ ! -d "$output_dir" ]]; then
-        output_dir=$(generate_project "preset-standard-otel" "standard-otel.yml")
+        output_dir=$(generate_project "preset-standard-otel" "_standard-otel.yml")
     fi
 
     cd "$output_dir"

--- a/test/presets.bats
+++ b/test/presets.bats
@@ -159,7 +159,7 @@ EOF
 
 @test "standard-otel preset: generates and builds" {
     local output_dir
-    output_dir=$(generate_project "preset-standard-otel" "standard-otel.yml")
+    output_dir=$(generate_project "preset-standard-otel" "_standard-otel.yml")
 
     cd "$output_dir"
     cargo_clippy "$output_dir"
@@ -213,7 +213,7 @@ EOF
 
     [[ -d "$output_dir" ]] || skip "full preset not built"
 
-    assert_file_in_project "$output_dir" "crates/test-full-core/benches"
+    assert_file_in_project "$output_dir" "crates/preset-full-core/benches"
 }
 
 @test "full preset: has site directory" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -80,6 +80,7 @@ generate_project() {
         --data "project_name=${test_name}"
         --data "owner=test-owner"
         --data "copyright_name=Test Copyright"
+        --data "conduct_email=conduct@test.org"
     )
 
     if [[ -n "$data_file" ]]; then
@@ -113,6 +114,7 @@ generate_project_with_data() {
         --data "project_name=${test_name}"
         --data "owner=test-owner"
         --data "copyright_name=Test Copyright"
+        --data "conduct_email=conduct@test.org"
     )
     for arg in "$@"; do
         data_args+=(--data "$arg")


### PR DESCRIPTION
## Summary

- Update standard-otel preset references to use `_standard-otel.yml` (file was renamed but tests were not updated)
- Add `conduct_email` to test defaults for full preset CODE_OF_CONDUCT generation
- Fix benches path assertion to use actual generated crate name (`preset-full-core`, not `test-full-core`)

## Test plan

- [x] `just test-presets` - 18/18 passing
- [x] `just test-fast` - 20/20 passing