### PR TITLE
fix(template): correct log directory, service name, and write safety

### DIFF
--- a/.config/scrat.yaml
+++ b/.config/scrat.yaml
@@ -1,0 +1,5 @@
+project:
+  type: generic
+
+commands:
+  test: just test-fast

--- a/template/{% if has_cli %}crates{% endif %}/{{ project_name + "-core" if has_core_library else "" }}/src/{% if has_core_library and (has_jsonl_logging or has_opentelemetry) %}observability.rs{% endif %}.jinja
+++ b/template/{% if has_cli %}crates{% endif %}/{{ project_name + "-core" if has_core_library else "" }}/src/{% if has_core_library and (has_jsonl_logging or has_opentelemetry) %}observability.rs{% endif %}.jinja
@@ -57,6 +57,7 @@ impl ObservabilityConfig {
     /// Create config from environment variables with optional overrides.
 {%- if has_opentelemetry %}
     pub fn from_env_with_overrides(
+        service: &str,
         otlp_endpoint: Option<String>,
         log_dir: Option<PathBuf>,
     ) -> Self {
@@ -65,7 +66,7 @@ impl ObservabilityConfig {
             .filter(|value| !value.trim().is_empty());
 
         Self {
-            service: env!("CARGO_PKG_NAME").to_string(),
+            service: service.to_string(),
             env: std::env::var(ENV_APP_ENV).unwrap_or_else(|_| "dev".to_string()),
             version: env!("CARGO_PKG_VERSION").to_string(),
             otlp_endpoint: env_endpoint.or(otlp_endpoint),
@@ -73,9 +74,9 @@ impl ObservabilityConfig {
         }
     }
 {%- else %}
-    pub fn from_env_with_overrides(log_dir: Option<PathBuf>) -> Self {
+    pub fn from_env_with_overrides(service: &str, log_dir: Option<PathBuf>) -> Self {
         Self {
-            service: env!("CARGO_PKG_NAME").to_string(),
+            service: service.to_string(),
             log_dir,
         }
     }
@@ -315,9 +316,12 @@ where
         event.record(&mut visitor);
         map.extend(visitor.values);
 
-        let mut writer = self.writer.make_writer();
-        if serde_json::to_writer(&mut writer, &Value::Object(map)).is_ok() {
-            let _ = writer.write_all(b"\n");
+        // Buffer the entire line so it's written in a single write() syscall,
+        // which is atomic with O_APPEND for lines under PIPE_BUF (typically 4096).
+        if let Ok(mut buf) = serde_json::to_vec(&Value::Object(map)) {
+            buf.push(b'\n');
+            let mut writer = self.writer.make_writer();
+            let _ = writer.write_all(&buf);
         }
     }
 }
@@ -476,9 +480,9 @@ fn resolve_log_target_with(
         candidates.push(PathBuf::from(DEFAULT_LOG_DIR_UNIX));
     }
 
-    // Use XDG-compliant data directory for log storage
-    if let Some(proj_dirs) = directories::ProjectDirs::from("", "", service) {
-        candidates.push(proj_dirs.data_local_dir().join("logs"));
+    // Platform-appropriate log directory
+    if let Some(log_dir) = platform_log_dir(service) {
+        candidates.push(log_dir);
     }
 
     if let Ok(dir) = std::env::current_dir() {
@@ -533,6 +537,29 @@ fn ensure_writable(dir: &Path, file_name: &str) -> Result<(), String> {
         .map_err(|e| format!("Failed to open log file {}: {e}", path.display()))?;
 
     Ok(())
+}
+
+/// Resolve the platform-appropriate log directory for a service.
+///
+/// - macOS: `~/Library/Logs/{service}/`
+/// - Linux/BSD: `$XDG_STATE_HOME/{service}/logs/` (default `~/.local/state/{service}/logs/`)
+/// - Windows: `{LocalAppData}/{service}/logs/` (via `directories` crate)
+fn platform_log_dir(service: &str) -> Option<PathBuf> {
+    if cfg!(target_os = "macos") {
+        std::env::var_os("HOME")
+            .map(|home| PathBuf::from(home).join("Library/Logs").join(service))
+    } else if cfg!(unix) {
+        let state_base = std::env::var_os("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HOME")
+                    .map(|home| PathBuf::from(home).join(".local/state"))
+            })?;
+        Some(state_base.join(service).join("logs"))
+    } else {
+        directories::ProjectDirs::from("", "", service)
+            .map(|p| p.data_local_dir().join("logs"))
+    }
 }
 
 // ============================================================================
@@ -622,6 +649,27 @@ mod tests {
     }
 
     #[test]
+    fn platform_log_dir_contains_service_name() {
+        let dir = platform_log_dir("test-svc").expect("platform_log_dir should return Some");
+        let path = dir.to_str().expect("path should be valid UTF-8");
+        assert!(
+            path.contains("test-svc"),
+            "log dir should contain service name: {path}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn platform_log_dir_uses_library_logs_on_macos() {
+        let dir = platform_log_dir("test-svc").unwrap();
+        let path = dir.to_str().unwrap();
+        assert!(
+            path.contains("Library/Logs"),
+            "macOS log dir should use ~/Library/Logs/: {path}"
+        );
+    }
+
+    #[test]
     fn days_to_ymd_known_dates() {
         // 1970-01-01 = day 0
         assert_eq!(days_to_ymd(0), (1970, 1, 1));
@@ -643,7 +691,7 @@ mod tests {
         unsafe {
             std::env::set_var(ENV_OTEL_ENDPOINT, "http://localhost:4317");
         }
-        let cfg = ObservabilityConfig::from_env_with_overrides(None, None);
+        let cfg = ObservabilityConfig::from_env_with_overrides("test-service", None, None);
         assert_eq!(cfg.otlp_endpoint, Some("http://localhost:4317".to_string()));
         // SAFETY: Single-threaded test, no concurrent env access
         unsafe {
@@ -658,6 +706,7 @@ mod tests {
             std::env::remove_var(ENV_OTEL_ENDPOINT);
         }
         let cfg = ObservabilityConfig::from_env_with_overrides(
+            "test-service",
             Some("http://custom:4317".to_string()),
             None,
         );
@@ -671,6 +720,7 @@ mod tests {
             std::env::set_var(ENV_OTEL_ENDPOINT, "http://env:4317");
         }
         let cfg = ObservabilityConfig::from_env_with_overrides(
+            "test-service",
             Some("http://param:4317".to_string()),
             None,
         );
@@ -688,6 +738,7 @@ mod tests {
             std::env::set_var(ENV_OTEL_ENDPOINT, "   ");
         }
         let cfg = ObservabilityConfig::from_env_with_overrides(
+            "test-service",
             Some("http://fallback:4317".to_string()),
             None,
         );

--- a/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/src/main.rs.jinja
+++ b/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/src/main.rs.jinja
@@ -71,6 +71,7 @@ fn main() -> anyhow::Result<()> {
 {%- if has_jsonl_logging or has_opentelemetry %}
 
     let obs_config = observability::ObservabilityConfig::from_env_with_overrides(
+        env!("CARGO_PKG_NAME"),
 {%- if has_opentelemetry and has_config %}
         config.otel_endpoint.clone(),
 {%- elif has_opentelemetry %}

--- a/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/src/{% if not has_core_library and (has_jsonl_logging or has_opentelemetry) %}observability.rs{% endif %}.jinja
+++ b/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/src/{% if not has_core_library and (has_jsonl_logging or has_opentelemetry) %}observability.rs{% endif %}.jinja
@@ -57,6 +57,7 @@ impl ObservabilityConfig {
     /// Create config from environment variables with optional overrides.
 {%- if has_opentelemetry %}
     pub fn from_env_with_overrides(
+        service: &str,
         otlp_endpoint: Option<String>,
         log_dir: Option<PathBuf>,
     ) -> Self {
@@ -65,7 +66,7 @@ impl ObservabilityConfig {
             .filter(|value| !value.trim().is_empty());
 
         Self {
-            service: env!("CARGO_PKG_NAME").to_string(),
+            service: service.to_string(),
             env: std::env::var(ENV_APP_ENV).unwrap_or_else(|_| "dev".to_string()),
             version: env!("CARGO_PKG_VERSION").to_string(),
             otlp_endpoint: env_endpoint.or(otlp_endpoint),
@@ -73,9 +74,9 @@ impl ObservabilityConfig {
         }
     }
 {%- else %}
-    pub fn from_env_with_overrides(log_dir: Option<PathBuf>) -> Self {
+    pub fn from_env_with_overrides(service: &str, log_dir: Option<PathBuf>) -> Self {
         Self {
-            service: env!("CARGO_PKG_NAME").to_string(),
+            service: service.to_string(),
             log_dir,
         }
     }
@@ -315,9 +316,12 @@ where
         event.record(&mut visitor);
         map.extend(visitor.values);
 
-        let mut writer = self.writer.make_writer();
-        if serde_json::to_writer(&mut writer, &Value::Object(map)).is_ok() {
-            let _ = writer.write_all(b"\n");
+        // Buffer the entire line so it's written in a single write() syscall,
+        // which is atomic with O_APPEND for lines under PIPE_BUF (typically 4096).
+        if let Ok(mut buf) = serde_json::to_vec(&Value::Object(map)) {
+            buf.push(b'\n');
+            let mut writer = self.writer.make_writer();
+            let _ = writer.write_all(&buf);
         }
     }
 }
@@ -476,9 +480,9 @@ fn resolve_log_target_with(
         candidates.push(PathBuf::from(DEFAULT_LOG_DIR_UNIX));
     }
 
-    // Use XDG-compliant data directory for log storage
-    if let Some(proj_dirs) = directories::ProjectDirs::from("", "", service) {
-        candidates.push(proj_dirs.data_local_dir().join("logs"));
+    // Platform-appropriate log directory
+    if let Some(log_dir) = platform_log_dir(service) {
+        candidates.push(log_dir);
     }
 
     if let Ok(dir) = std::env::current_dir() {
@@ -533,6 +537,29 @@ fn ensure_writable(dir: &Path, file_name: &str) -> Result<(), String> {
         .map_err(|e| format!("Failed to open log file {}: {e}", path.display()))?;
 
     Ok(())
+}
+
+/// Resolve the platform-appropriate log directory for a service.
+///
+/// - macOS: `~/Library/Logs/{service}/`
+/// - Linux/BSD: `$XDG_STATE_HOME/{service}/logs/` (default `~/.local/state/{service}/logs/`)
+/// - Windows: `{LocalAppData}/{service}/logs/` (via `directories` crate)
+fn platform_log_dir(service: &str) -> Option<PathBuf> {
+    if cfg!(target_os = "macos") {
+        std::env::var_os("HOME")
+            .map(|home| PathBuf::from(home).join("Library/Logs").join(service))
+    } else if cfg!(unix) {
+        let state_base = std::env::var_os("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HOME")
+                    .map(|home| PathBuf::from(home).join(".local/state"))
+            })?;
+        Some(state_base.join(service).join("logs"))
+    } else {
+        directories::ProjectDirs::from("", "", service)
+            .map(|p| p.data_local_dir().join("logs"))
+    }
 }
 
 // ============================================================================
@@ -622,6 +649,27 @@ mod tests {
     }
 
     #[test]
+    fn platform_log_dir_contains_service_name() {
+        let dir = platform_log_dir("test-svc").expect("platform_log_dir should return Some");
+        let path = dir.to_str().expect("path should be valid UTF-8");
+        assert!(
+            path.contains("test-svc"),
+            "log dir should contain service name: {path}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn platform_log_dir_uses_library_logs_on_macos() {
+        let dir = platform_log_dir("test-svc").unwrap();
+        let path = dir.to_str().unwrap();
+        assert!(
+            path.contains("Library/Logs"),
+            "macOS log dir should use ~/Library/Logs/: {path}"
+        );
+    }
+
+    #[test]
     fn days_to_ymd_known_dates() {
         // 1970-01-01 = day 0
         assert_eq!(days_to_ymd(0), (1970, 1, 1));
@@ -643,7 +691,7 @@ mod tests {
         unsafe {
             std::env::set_var(ENV_OTEL_ENDPOINT, "http://localhost:4317");
         }
-        let cfg = ObservabilityConfig::from_env_with_overrides(None, None);
+        let cfg = ObservabilityConfig::from_env_with_overrides("test-service", None, None);
         assert_eq!(cfg.otlp_endpoint, Some("http://localhost:4317".to_string()));
         // SAFETY: Single-threaded test, no concurrent env access
         unsafe {
@@ -658,6 +706,7 @@ mod tests {
             std::env::remove_var(ENV_OTEL_ENDPOINT);
         }
         let cfg = ObservabilityConfig::from_env_with_overrides(
+            "test-service",
             Some("http://custom:4317".to_string()),
             None,
         );
@@ -671,6 +720,7 @@ mod tests {
             std::env::set_var(ENV_OTEL_ENDPOINT, "http://env:4317");
         }
         let cfg = ObservabilityConfig::from_env_with_overrides(
+            "test-service",
             Some("http://param:4317".to_string()),
             None,
         );
@@ -688,6 +738,7 @@ mod tests {
             std::env::set_var(ENV_OTEL_ENDPOINT, "   ");
         }
         let cfg = ObservabilityConfig::from_env_with_overrides(
+            "test-service",
             Some("http://fallback:4317".to_string()),
             None,
         );

--- a/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/tests/cli.rs
+++ b/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/tests/cli.rs
@@ -12,7 +12,12 @@ use predicates::prelude::*;
 /// cargo build directories, but works correctly for standard project layouts.
 #[allow(deprecated)]
 fn cmd() -> Command {
-    Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    // Route log output to a temp directory so tests don't write to production paths
+    let prefix = env!("CARGO_PKG_NAME").to_uppercase().replace('-', "_");
+    let test_log_dir = std::env::temp_dir().join(format!("{}-test-logs", env!("CARGO_PKG_NAME")));
+    cmd.env(format!("{prefix}_LOG_DIR"), test_log_dir);
+    cmd
 }
 
 // =============================================================================

--- a/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/tests/{% if has_config %}config_integration.rs{% endif %}.jinja
+++ b/template/{% if has_cli %}crates{% endif %}/{{ project_name if has_cli else "" }}/tests/{% if has_config %}config_integration.rs{% endif %}.jinja
@@ -14,7 +14,13 @@ use tempfile::TempDir;
 /// Returns a Command configured to run our binary.
 #[allow(deprecated)]
 fn cmd() -> Command {
-    Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    // Route log output to a temp directory so tests don't write to production paths
+    let prefix = env!("CARGO_PKG_NAME").to_uppercase().replace('-', "_");
+    let test_log_dir =
+        std::env::temp_dir().join(format!("{}-test-logs", env!("CARGO_PKG_NAME")));
+    cmd.env(format!("{prefix}_LOG_DIR"), test_log_dir);
+    cmd
 }
 
 /// Run `info --json` from a directory and parse the JSON output.


### PR DESCRIPTION
Fix four observability bugs found via scrat log investigation:
- Use ~/Library/Logs/ on macOS and $XDG_STATE_HOME on Linux
  instead of ~/Library/Application Support/ (wrong directory)
- Accept service name as parameter instead of using
  env!("CARGO_PKG_NAME") which evaluates to the wrong crate
  in core-library workspaces
- Buffer JSON + newline into single write_all call for atomic
  O_APPEND writes across parallel nextest processes
- Set {SERVICE}_LOG_DIR in integration test cmd() helpers to
  route log output to temp dir instead of production paths
Release-Note: Fix log directory and concurrent write safety
Release-Impact: medium